### PR TITLE
Palette Atlas

### DIFF
--- a/sadx-dc-lighting/EffectParameter.cpp
+++ b/sadx-dc-lighting/EffectParameter.cpp
@@ -3,28 +3,6 @@
 #include "EffectParameter.h"
 
 template<>
-void EffectParameter<IDirect3DTexture9*>::operator=(IDirect3DTexture9* const& value)
-{
-	// Comparing pointers is almost certainly faster
-	// than just making the add/release calls.
-	if (value != current)
-	{
-		if (value)
-		{
-			value->AddRef();
-		}
-
-		if (current)
-		{
-			current->Release();
-		}
-	}
-
-	assigned = true;
-	current = value;
-}
-
-template<>
 void EffectParameter<bool>::Commit()
 {
 	if (Modified())
@@ -97,7 +75,7 @@ void EffectParameter<D3DXMATRIX>::Commit()
 }
 
 template<>
-void EffectParameter<IDirect3DTexture9*>::Commit()
+void EffectParameter<Texture>::Commit()
 {
 	if (Modified())
 	{

--- a/sadx-dc-lighting/EffectParameter.h
+++ b/sadx-dc-lighting/EffectParameter.h
@@ -39,6 +39,7 @@ public:
 	void Clear() override;
 	void Commit() override;
 	void operator=(const T& value);
+	void operator=(const EffectParameter<T>& value);
 };
 
 template <typename T>
@@ -68,6 +69,12 @@ void EffectParameter<T>::operator=(const T& value)
 {
 	assigned = true;
 	current = value;
+}
+
+template <typename T>
+void EffectParameter<T>::operator=(const EffectParameter<T>& value)
+{
+	*this = value.current;
 }
 
 template<> void EffectParameter<bool>::Commit();

--- a/sadx-dc-lighting/EffectParameter.h
+++ b/sadx-dc-lighting/EffectParameter.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <string>
+#include <atlbase.h>
 #include <d3d9.h>
 #include <d3dx9effect.h>
+
+using Texture = CComPtr<IDirect3DTexture9>;
 
 class IEffectParameter
 {
@@ -67,8 +70,6 @@ void EffectParameter<T>::operator=(const T& value)
 	current = value;
 }
 
-template<> void EffectParameter<IDirect3DTexture9*>::operator=(IDirect3DTexture9* const& value);
-
 template<> void EffectParameter<bool>::Commit();
 template<> void EffectParameter<int>::Commit();
 template<> void EffectParameter<float>::Commit();
@@ -76,4 +77,4 @@ template<> void EffectParameter<D3DXVECTOR4>::Commit();
 template<> void EffectParameter<D3DXVECTOR3>::Commit();
 template<> void EffectParameter<D3DXCOLOR>::Commit();
 template<> void EffectParameter<D3DXMATRIX>::Commit();
-template<> void EffectParameter<IDirect3DTexture9*>::Commit();
+template<> void EffectParameter<Texture>::Commit();

--- a/sadx-dc-lighting/Obj_Past.cpp
+++ b/sadx-dc-lighting/Obj_Past.cpp
@@ -2,6 +2,7 @@
 
 #include "d3d.h"
 #include <SADXModLoader.h>
+#include <Trampoline.h>
 
 #include "lantern.h"
 #include "globals.h"

--- a/sadx-dc-lighting/Obj_SkyDeck.cpp
+++ b/sadx-dc-lighting/Obj_SkyDeck.cpp
@@ -63,7 +63,7 @@ static void __cdecl Obj_SkyDeck_r(ObjectMaster* _this)
 	globals::palettes.LoadPalette(LevelIDs_SkyDeck, 0);
 	globals::palettes.LoadSource(LevelIDs_SkyDeck, 0);
 
-	LanternInstance lantern(&param::DiffusePaletteB, &param::SpecularPaletteB);
+	LanternInstance lantern(&param::PaletteB, &param::DiffuseIndexB, &param::SpecularIndexB);
 	lantern.LoadPalette(LevelIDs_SkyDeck, 1);
 	handle = globals::palettes.Add(lantern);
 }

--- a/sadx-dc-lighting/d3d.cpp
+++ b/sadx-dc-lighting/d3d.cpp
@@ -83,11 +83,16 @@ namespace d3d
 
 namespace param
 {
-	EffectParameter<IDirect3DTexture9*> BaseTexture(&d3d::effect, "BaseTexture", nullptr);
-	EffectParameter<IDirect3DTexture9*> DiffusePalette(&d3d::effect, "DiffusePalette", nullptr);
-	EffectParameter<IDirect3DTexture9*> DiffusePaletteB(&d3d::effect, "DiffusePaletteB", nullptr);
-	EffectParameter<IDirect3DTexture9*> SpecularPalette(&d3d::effect, "SpecularPalette", nullptr);
-	EffectParameter<IDirect3DTexture9*> SpecularPaletteB(&d3d::effect, "SpecularPaletteB", nullptr);
+	EffectParameter<Texture> BaseTexture(&d3d::effect, "BaseTexture", nullptr);
+
+	EffectParameter<Texture> PaletteA(&d3d::effect, "PaletteA", nullptr);
+	EffectParameter<float> DiffuseIndexA(&d3d::effect, "DiffuseIndexA", 0.0f);
+	EffectParameter<float> SpecularIndexA(&d3d::effect, "SpecularIndexA", 0.0f);
+
+	EffectParameter<Texture> PaletteB(&d3d::effect, "PaletteB", nullptr);
+	EffectParameter<float> DiffuseIndexB(&d3d::effect, "DiffuseIndexB", 0.0f);
+	EffectParameter<float> SpecularIndexB(&d3d::effect, "SpecularIndexB", 0.0f);
+
 	EffectParameter<float> BlendFactor(&d3d::effect, "BlendFactor", 0.0f);
 	EffectParameter<D3DXMATRIX> WorldMatrix(&d3d::effect, "WorldMatrix", {});
 	EffectParameter<D3DXMATRIX> wvMatrix(&d3d::effect, "wvMatrix", {});
@@ -119,10 +124,15 @@ namespace param
 
 	static IEffectParameter* const parameters[] = {
 		&BaseTexture,
-		&DiffusePalette,
-		&DiffusePaletteB,
-		&SpecularPalette,
-		&SpecularPaletteB,
+
+		&PaletteA,
+		&DiffuseIndexA,
+		&SpecularIndexA,
+
+		&PaletteB,
+		&DiffuseIndexB,
+		&SpecularIndexB,
+		
 		&BlendFactor,
 		&WorldMatrix,
 		&wvMatrix,

--- a/sadx-dc-lighting/d3d.h
+++ b/sadx-dc-lighting/d3d.h
@@ -19,11 +19,17 @@ namespace d3d
 
 namespace param
 {
-	extern EffectParameter<IDirect3DTexture9*> BaseTexture;
-	extern EffectParameter<IDirect3DTexture9*> DiffusePalette;
-	extern EffectParameter<IDirect3DTexture9*> DiffusePaletteB;
-	extern EffectParameter<IDirect3DTexture9*> SpecularPalette;
-	extern EffectParameter<IDirect3DTexture9*> SpecularPaletteB;
+	extern EffectParameter<Texture> BaseTexture;
+
+	extern EffectParameter<Texture> PaletteA;
+	extern EffectParameter<float> DiffuseIndexA;
+	extern EffectParameter<float> SpecularIndexA;
+
+
+	extern EffectParameter<Texture> PaletteB;
+	extern EffectParameter<float> DiffuseIndexB;
+	extern EffectParameter<float> SpecularIndexB;
+
 	extern EffectParameter<float> BlendFactor;
 	extern EffectParameter<D3DXMATRIX> WorldMatrix;
 	extern EffectParameter<D3DXMATRIX> wvMatrix;

--- a/sadx-dc-lighting/lantern.cpp
+++ b/sadx-dc-lighting/lantern.cpp
@@ -518,16 +518,16 @@ void LanternInstance::SetBlendFactor(float f)
 	blend_factor = f;
 }
 
-inline float _index(Sint32 i, float offset)
+inline float _index(Sint32 i, Sint32 offset)
 {
-	return (2.0f * (float)i + offset) / 15.5f;
+	return ((float)(2 * i + offset) + 0.5f) / 16.0f;
 }
 
 void LanternInstance::set_diffuse(Sint32 diffuse) const
 {
 	if (diffuse >= 0)
 	{
-		*diffuse_param = _index(diffuse, 0.0f);
+		*diffuse_param = _index(diffuse, 0);
 	}
 }
 
@@ -535,7 +535,7 @@ void LanternInstance::set_specular(Sint32 specular) const
 {
 	if (specular >= 0)
 	{
-		*specular_param = _index(specular, 1.0f);
+		*specular_param = _index(specular, 1);
 	}
 }
 
@@ -637,12 +637,12 @@ void LanternInstance::SetSelfBlend(Sint32 type, Sint32 diffuse, Sint32 specular)
 
 	if (diffuse > -1)
 	{
-		param::DiffuseIndexB = _index(diffuse, 0.0f);
+		param::DiffuseIndexB = _index(diffuse, 0);
 	}
 
 	if (specular > -1)
 	{
-		param::SpecularIndexB = _index(specular, 1.0f);
+		param::SpecularIndexB = _index(specular, 1);
 	}
 }
 

--- a/sadx-dc-lighting/lantern.cpp
+++ b/sadx-dc-lighting/lantern.cpp
@@ -634,6 +634,7 @@ void LanternInstance::SetSelfBlend(Sint32 type, Sint32 diffuse, Sint32 specular)
 	}
 
 	blend_type = type;
+	param::PaletteB = param::PaletteA;
 
 	if (diffuse > -1)
 	{

--- a/sadx-dc-lighting/lantern.cpp
+++ b/sadx-dc-lighting/lantern.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 
+#include <atlbase.h>
 #include <d3d9.h>
+
 #include <exception>
 #include <string>
 #include <sstream>
@@ -41,76 +43,6 @@ void EffectParameter<SourceLight_t>::Commit()
 		(*effect)->SetValue(handle, &current, sizeof(SourceLight_t));
 		Clear();
 	}
-}
-
-/// <summary>
-/// Get the pixel data of the specified texture.
-/// </summary>
-/// <param name="texture">The texture to lock.</param>
-/// <returns>The locked rect.</returns>
-inline D3DLOCKED_RECT GetTextureRect(IDirect3DTexture9* texture)
-{
-	D3DLOCKED_RECT result;
-	HRESULT hresult = texture->LockRect(0, &result, nullptr, 0);
-	if (FAILED(hresult))
-	{
-		throw std::exception("Failed to lock texture rect!");
-	}
-	return result;
-}
-
-/// <summary>
-/// Creates a 1x256 image to be used as a palette.
-/// </summary>
-/// <param name="texture">Destination texture.</param>
-inline void CreateTexture(IDirect3DTexture9*& texture)
-{
-	if (texture)
-	{
-		texture->Release();
-		texture = nullptr;
-	}
-
-	if (FAILED(d3d::device->CreateTexture(256, 1, 1, 0, D3DFMT_X8R8G8B8, D3DPOOL_MANAGED, &texture, nullptr)))
-	{
-		throw std::exception("Failed to create palette texture!");
-	}
-}
-
-/// <summary>
-/// Creates a pair of texture palettes from the provided color pairs.
-/// </summary>
-/// <param name="palette">The destination palette structure.</param>
-/// <param name="pairs">Array of 256 color pairs. (512 total)</param>
-static void CreatePaletteTexturePair(LanternPalette& palette, const ColorPair* pairs)
-{
-	using namespace d3d;
-	if (device == nullptr)
-	{
-		throw std::exception("Device is null.");
-	}
-
-	CreateTexture(palette.diffuse);
-	CreateTexture(palette.specular);
-
-	auto diffuse_rect = GetTextureRect(palette.diffuse);
-	auto diffuse_data = (NJS_COLOR*)diffuse_rect.pBits;
-
-	auto specular_rect = GetTextureRect(palette.specular);
-	auto specular_data = (NJS_COLOR*)specular_rect.pBits;
-
-	for (size_t i = 0; i < 256; i++)
-	{
-		const auto& pair = pairs[i];
-		auto& diffuse = diffuse_data[i];
-		auto& specular = specular_data[i];
-
-		diffuse = pair.diffuse;
-		specular = pair.specular;
-	}
-
-	palette.diffuse->UnlockRect(0);
-	palette.specular->UnlockRect(0);
 }
 
 /*
@@ -345,64 +277,32 @@ std::string LanternInstance::PaletteId(Sint32 level, Sint32 act)
 	return result.str();
 }
 
-LanternInstance::LanternInstance(EffectParameter<IDirect3DTexture9*>* diffuse, EffectParameter<IDirect3DTexture9*>* specular)
-	: diffuse_param(diffuse), specular_param(specular),
-	  blend_type(-1), last_time(-1), last_act(-1), last_level(-1)
+LanternInstance::LanternInstance(EffectParameter<Texture>* atlas, EffectParameter<float>* diffuse_param, EffectParameter<float>* specular_param)
+	: atlas(atlas), diffuse_param(diffuse_param), specular_param(specular_param), blend_type(-1), last_time(-1), last_act(-1), last_level(-1)
 {
-	for (auto& i : palette)
-	{
-		i = {};
-	}
 }
 
 LanternInstance::LanternInstance(LanternInstance&& inst) noexcept
-	: diffuse_param(inst.diffuse_param), specular_param(inst.specular_param),
-	  blend_type(inst.blend_type), last_time(inst.last_time), last_act(inst.last_act), last_level(inst.last_level)
+	: atlas(inst.atlas), diffuse_param(inst.diffuse_param), specular_param(inst.specular_param),
+	blend_type(inst.blend_type), last_time(inst.last_time), last_act(inst.last_act), last_level(inst.last_level)
 {
-	for (int i = 0; i < 8; i++)
-	{
-		palette[i] = inst.palette[i];
-		inst.palette[i] = {};
-	}
 }
 
 LanternInstance& LanternInstance::operator=(LanternInstance&& inst) noexcept
 {
-	diffuse_param  = inst.diffuse_param;
-	specular_param = inst.specular_param;
+	atlas          = inst.atlas;
 	last_time      = inst.last_time;
 	last_act       = inst.last_act;
 	last_level     = inst.last_level;
 	blend_type     = inst.blend_type;
 
-	inst.diffuse_param = nullptr;
-	inst.specular_param = nullptr;
-
-	for (int i = 0; i < 8; i++)
-	{
-		palette[i] = inst.palette[i];
-		inst.palette[i] = {};
-	}
+	inst.atlas = nullptr;
 
 	return *this;
 }
 
 LanternInstance::~LanternInstance()
 {
-	for (auto& i : palette)
-	{
-		if (i.diffuse)
-		{
-			i.diffuse->Release();
-			i.diffuse = nullptr;
-		}
-
-		if (i.specular)
-		{
-			i.specular->Release();
-			i.specular = nullptr;
-		}
-	}
 }
 
 void LanternInstance::SetLastLevel(Sint32 level, Sint32 act)
@@ -486,7 +386,7 @@ bool LanternInstance::LoadFiles()
 /// <returns><c>true</c> on success.</returns>
 bool LanternInstance::LoadPalette(const std::string& path)
 {
-	auto file = std::ifstream(path, std::ios::binary);
+	std::ifstream file(path, std::ios::binary);
 
 	if (!file.is_open())
 	{
@@ -508,30 +408,43 @@ bool LanternInstance::LoadPalette(const std::string& path)
 
 	file.close();
 
+	Texture texture = nullptr;
+
+	if (FAILED(d3d::device->CreateTexture(256, 16, 1, 0, D3DFMT_X8R8G8B8, D3DPOOL_MANAGED, &texture, nullptr)))
+	{
+		throw std::exception("Failed to create palette texture!");
+	}
+
+	*atlas = texture;
+
+	D3DLOCKED_RECT rect;
+	if (FAILED(texture->LockRect(0, &rect, nullptr, 0)))
+	{
+		throw std::exception("Failed to lock texture rect!");
+	}
+
+	auto pixels = (NJS_COLOR*)rect.pBits;
+
 	for (size_t i = 0; i < 8; i++)
 	{
 		auto index = i * 256;
-		if (index < colorData.size() && index + 256 < colorData.size())
+		if (index >= colorData.size() || index + 256 >= colorData.size())
 		{
-			CreatePaletteTexturePair(palette[i], &colorData[index]);
+			break;
 		}
-		else
+
+		auto y = 512 * i;
+		for (size_t x = 0; x < 256; x++)
 		{
-			auto& pair = palette[i];
-
-			if (pair.diffuse)
-			{
-				pair.diffuse->Release();
-				pair.diffuse = nullptr;
-			}
-
-			if (pair.specular)
-			{
-				pair.specular->Release();
-				pair.specular = nullptr;
-			}
+			auto& diffuse = pixels[y + x];
+			auto& specular = pixels[256 + y + x];
+			const auto& color = colorData[index + x];
+			diffuse = color.diffuse;
+			specular = color.specular;
 		}
 	}
+
+	texture->UnlockRect(0);
 
 	return true;
 }
@@ -605,11 +518,16 @@ void LanternInstance::SetBlendFactor(float f)
 	blend_factor = f;
 }
 
+inline float _index(Sint32 i, float offset)
+{
+	return (2.0f * (float)i + offset) / 15.5f;
+}
+
 void LanternInstance::set_diffuse(Sint32 diffuse) const
 {
 	if (diffuse >= 0)
 	{
-		*diffuse_param = palette[diffuse].diffuse;
+		*diffuse_param = _index(diffuse, 0.0f);
 	}
 }
 
@@ -617,7 +535,7 @@ void LanternInstance::set_specular(Sint32 specular) const
 {
 	if (specular >= 0)
 	{
-		*specular_param = palette[specular].specular;
+		*specular_param = _index(specular, 1.0f);
 	}
 }
 
@@ -711,8 +629,7 @@ void LanternInstance::SetSelfBlend(Sint32 type, Sint32 diffuse, Sint32 specular)
 	if (type < 0)
 	{
 		blend_type = -1;
-		param::DiffusePaletteB = nullptr;
-		param::SpecularPaletteB = nullptr;
+		param::PaletteB = nullptr;
 		return;
 	}
 
@@ -720,12 +637,12 @@ void LanternInstance::SetSelfBlend(Sint32 type, Sint32 diffuse, Sint32 specular)
 
 	if (diffuse > -1)
 	{
-		param::DiffusePaletteB = palette[diffuse].diffuse;
+		param::DiffuseIndexB = _index(diffuse, 0.0f);
 	}
 
 	if (specular > -1)
 	{
-		param::SpecularPaletteB = palette[specular].specular;
+		param::SpecularIndexB = _index(specular, 1.0f);
 	}
 }
 
@@ -805,7 +722,7 @@ bool LanternCollection::LoadFiles()
 
 	if (instances.empty())
 	{
-		instances.push_back(LanternInstance(&param::DiffusePalette, &param::SpecularPalette));
+		instances.emplace_back(&param::PaletteA, &param::DiffuseIndexA, &param::SpecularIndexA);
 	}
 
 	for (auto& i : instances)

--- a/sadx-dc-lighting/lantern.h
+++ b/sadx-dc-lighting/lantern.h
@@ -8,14 +8,6 @@
 
 #include "EffectParameter.h"
 
-struct LanternPalette
-{
-	// The first set of colors in the pair.
-	IDirect3DTexture9* diffuse;
-	// The second set of colors in the pair.
-	IDirect3DTexture9* specular;
-};
-
 #pragma pack(push, 1)
 struct SourceLight_t
 {
@@ -61,9 +53,9 @@ class LanternInstance : ILantern
 	static float blend_factor;
 	static bool use_palette;
 
-	EffectParameter<IDirect3DTexture9*>* diffuse_param;
-	EffectParameter<IDirect3DTexture9*>* specular_param;
-	LanternPalette palette[8];
+	EffectParameter<Texture>* atlas;
+	EffectParameter<float>* diffuse_param;
+	EffectParameter<float>* specular_param;
 
 	Sint32 blend_type;
 	Sint8 last_time;
@@ -74,7 +66,7 @@ class LanternInstance : ILantern
 	void set_specular(Sint32 specular) const;
 
 public:
-	LanternInstance(EffectParameter<IDirect3DTexture9*>* diffuse, EffectParameter<IDirect3DTexture9*>* specular);
+	LanternInstance(EffectParameter<Texture>* atlas, EffectParameter<float>* diffuse_param, EffectParameter<float>* specular_param);
 	LanternInstance(LanternInstance&& instance) noexcept;
 
 	LanternInstance(const LanternInstance&) = default;

--- a/sadx-dc-lighting/mod.cpp
+++ b/sadx-dc-lighting/mod.cpp
@@ -12,6 +12,7 @@
 #include "globals.h"
 #include "lantern.h"
 #include "Obj_Past.h"
+#include "Obj_SkyDeck.h"
 #include "FixChaoGardenMaterials.h"
 #include "FixCharacterMaterials.h"
 
@@ -334,7 +335,7 @@ extern "C"
 			return;
 		}
 
-		LanternInstance base(&param::DiffusePalette, &param::SpecularPalette);
+		LanternInstance base(&param::PaletteA, &param::DiffuseIndexA, &param::SpecularIndexA);
 		globals::palettes.Add(base);
 
 		globals::system = path;

--- a/sadx-dc-lighting/stdafx.h
+++ b/sadx-dc-lighting/stdafx.h
@@ -18,6 +18,7 @@
 #if 1
 // Windows API
 #include <Windows.h>
+#include <atlbase.h>
 
 // Direct3D
 #include <d3d9.h>


### PR DESCRIPTION
This replaces the separate palette textures with a single palette atlas texture to reduce texture switching overhead. It also takes advantage of `CComPtr` to perform automatic reference counting on all stored texture pointers.

Fixes #33 