### PR TITLE
Dynamic shader compilation

### DIFF
--- a/sadx-dc-lighting/EffectParameter.cpp
+++ b/sadx-dc-lighting/EffectParameter.cpp
@@ -3,83 +3,83 @@
 #include "EffectParameter.h"
 
 template<>
-void EffectParameter<bool>::Commit()
+void EffectParameter<bool>::Commit(Effect effect)
 {
 	if (Modified())
 	{
-		(*effect)->SetBool(handle, current);
+		effect->SetBool(handle, current);
 		Clear();
 	}
 }
 
 template<>
-void EffectParameter<int>::Commit()
+void EffectParameter<int>::Commit(Effect effect)
 {
 	if (Modified())
 	{
-		(*effect)->SetInt(handle, current);
+		effect->SetInt(handle, current);
 		Clear();
 	}
 }
 
 template<>
-void EffectParameter<float>::Commit()
+void EffectParameter<float>::Commit(Effect effect)
 {
 	if (Modified())
 	{
-		(*effect)->SetFloat(handle, current);
+		effect->SetFloat(handle, current);
 		Clear();
 	}
 }
 
 template<>
-void EffectParameter<D3DXVECTOR4>::Commit()
+void EffectParameter<D3DXVECTOR4>::Commit(Effect effect)
 {
 	if (Modified())
 	{
-		(*effect)->SetVector(handle, &current);
+		effect->SetVector(handle, &current);
 		Clear();
 	}
 }
 
 template<>
-void EffectParameter<D3DXVECTOR3>::Commit()
+void EffectParameter<D3DXVECTOR3>::Commit(Effect effect)
 {
 	if (Modified())
 	{
 		D3DXVECTOR4 v = D3DXVECTOR4(current, 0.0f);
-		(*effect)->SetVector(handle, &v);
+		effect->SetVector(handle, &v);
 		Clear();
 	}
 }
 
 template<>
-void EffectParameter<D3DXCOLOR>::Commit()
+void EffectParameter<D3DXCOLOR>::Commit(Effect effect)
 {
 	if (Modified())
 	{
 		static_assert(sizeof(D3DXCOLOR) == sizeof(D3DXVECTOR4), "D3DXCOLOR size does not match D3DXVECTOR4.");
-		(*effect)->SetVector(handle, (D3DXVECTOR4*)&current);
+		effect->SetVector(handle, (D3DXVECTOR4*)&current);
 		Clear();
 	}
 }
 
 template<>
-void EffectParameter<D3DXMATRIX>::Commit()
+void EffectParameter<D3DXMATRIX>::Commit(Effect effect)
 {
 	if (Modified())
 	{
-		(*effect)->SetMatrix(handle, &current);
+		effect->SetMatrix(handle, &current);
 		Clear();
 	}
 }
 
 template<>
-void EffectParameter<Texture>::Commit()
+void EffectParameter<Texture>::Commit(Effect effect)
 {
 	if (Modified())
 	{
-		(*effect)->SetTexture(handle, current);
+		effect->SetTexture(handle, current);
 		Clear();
 	}
 }

--- a/sadx-dc-lighting/EffectParameter.cpp
+++ b/sadx-dc-lighting/EffectParameter.cpp
@@ -83,3 +83,11 @@ void EffectParameter<Texture>::Commit(Effect effect)
 		Clear();
 	}
 }
+
+template<>
+void EffectParameter<Texture>::Release()
+{
+	Clear();
+	current = nullptr;
+	last = nullptr;
+}

--- a/sadx-dc-lighting/EffectParameter.h
+++ b/sadx-dc-lighting/EffectParameter.h
@@ -16,6 +16,7 @@ public:
 	virtual bool Modified() = 0;
 	virtual void Clear() = 0;
 	virtual void Commit(Effect effect) = 0;
+	virtual void Release() = 0;
 };
 
 template<typename T>
@@ -38,6 +39,7 @@ public:
 	bool Modified() override;
 	void Clear() override;
 	void Commit(Effect effect) override;
+	void Release() override;
 	void operator=(const T& value);
 	void operator=(const EffectParameter<T>& value);
 };
@@ -65,6 +67,12 @@ void EffectParameter<T>::Clear()
 }
 
 template <typename T>
+void EffectParameter<T>::Release()
+{
+	Clear();
+}
+
+template <typename T>
 void EffectParameter<T>::operator=(const T& value)
 {
 	assigned = true;
@@ -85,3 +93,4 @@ template<> void EffectParameter<D3DXVECTOR3>::Commit(Effect effect);
 template<> void EffectParameter<D3DXCOLOR>::Commit(Effect effect);
 template<> void EffectParameter<D3DXMATRIX>::Commit(Effect effect);
 template<> void EffectParameter<Texture>::Commit(Effect effect);
+template<> void EffectParameter<Texture>::Release();

--- a/sadx-dc-lighting/EffectParameter.h
+++ b/sadx-dc-lighting/EffectParameter.h
@@ -6,22 +6,22 @@
 #include <d3dx9effect.h>
 
 using Texture = CComPtr<IDirect3DTexture9>;
+using Effect = CComPtr<ID3DXEffect>;
 
 class IEffectParameter
 {
 public:
 	virtual ~IEffectParameter() = default;
-	virtual void UpdateHandle() = 0;
+	virtual void UpdateHandle(Effect effect) = 0;
 	virtual bool Modified() = 0;
 	virtual void Clear() = 0;
-	virtual void Commit() = 0;
+	virtual void Commit(Effect effect) = 0;
 };
 
 template<typename T>
 class EffectParameter : public IEffectParameter
 {
-	const std::string name;
-	ID3DXEffect** effect;
+	const char* name;
 	D3DXHANDLE handle;
 	bool reset;
 	bool assigned;
@@ -29,15 +29,15 @@ class EffectParameter : public IEffectParameter
 	T current;
 
 public:
-	explicit EffectParameter(ID3DXEffect** effect, const std::string& name, const T& defaultValue)
-		: name(name), effect(effect), handle(nullptr), reset(false), assigned(false), last(defaultValue), current(defaultValue)
+	explicit EffectParameter(const char* name, const T& defaultValue)
+		: name(name), handle(nullptr), reset(false), assigned(false), last(defaultValue), current(defaultValue)
 	{
 	}
 
-	void UpdateHandle() override;
+	void UpdateHandle(Effect effect) override;
 	bool Modified() override;
 	void Clear() override;
-	void Commit() override;
+	void Commit(Effect effect) override;
 	void operator=(const T& value);
 	void operator=(const EffectParameter<T>& value);
 };
@@ -49,11 +49,11 @@ bool EffectParameter<T>::Modified()
 }
 
 template <typename T>
-void EffectParameter<T>::UpdateHandle()
+void EffectParameter<T>::UpdateHandle(Effect effect)
 {
 	reset = handle != nullptr;
-	handle = (*effect)->GetParameterByName(nullptr, name.c_str());
-	Commit();
+	handle = effect->GetParameterByName(nullptr, name);
+	Commit(effect);
 }
 
 template <typename T>
@@ -77,11 +77,11 @@ void EffectParameter<T>::operator=(const EffectParameter<T>& value)
 	*this = value.current;
 }
 
-template<> void EffectParameter<bool>::Commit();
-template<> void EffectParameter<int>::Commit();
-template<> void EffectParameter<float>::Commit();
-template<> void EffectParameter<D3DXVECTOR4>::Commit();
-template<> void EffectParameter<D3DXVECTOR3>::Commit();
-template<> void EffectParameter<D3DXCOLOR>::Commit();
-template<> void EffectParameter<D3DXMATRIX>::Commit();
-template<> void EffectParameter<Texture>::Commit();
+template<> void EffectParameter<bool>::Commit(Effect effect);
+template<> void EffectParameter<int>::Commit(Effect effect);
+template<> void EffectParameter<float>::Commit(Effect effect);
+template<> void EffectParameter<D3DXVECTOR4>::Commit(Effect effect);
+template<> void EffectParameter<D3DXVECTOR3>::Commit(Effect effect);
+template<> void EffectParameter<D3DXCOLOR>::Commit(Effect effect);
+template<> void EffectParameter<D3DXMATRIX>::Commit(Effect effect);
+template<> void EffectParameter<Texture>::Commit(Effect effect);

--- a/sadx-dc-lighting/FixChaoGardenMaterials.cpp
+++ b/sadx-dc-lighting/FixChaoGardenMaterials.cpp
@@ -3,6 +3,8 @@
 #include <Trampoline.h>
 #include "FixChaoGardenMaterials.h"
 
+#include "datapointers.h"
+
 // Static materials (in the main exe)
 #include "ssgarden.h"
 #include "ecgarden.h"

--- a/sadx-dc-lighting/Obj_Past.cpp
+++ b/sadx-dc-lighting/Obj_Past.cpp
@@ -18,7 +18,7 @@ static Trampoline* Obj_Past_t = nullptr;
 
 static void __cdecl Obj_Past_Delete_r(ObjectMaster* _this)
 {
-	LanternInstance::SetBlendFactor(0.0f);
+	SetShaderOptions(d3d::ShaderOptions::UseBlending, false);
 	Obj_Past_Delete(_this);
 }
 
@@ -28,6 +28,8 @@ static void __cdecl Obj_Past_r(ObjectMaster *_this)
 	switch (entity->Action)
 	{
 		case 0:
+			SetShaderOptions(d3d::ShaderOptions::UseBlending, true);
+
 			entity->InvulnerableTime = CurrentAct;
 			sub_543F20();
 			memset((void*)0x3C63690, 0, sizeof(ObjectMaster*) * 4);

--- a/sadx-dc-lighting/Obj_SkyDeck.cpp
+++ b/sadx-dc-lighting/Obj_SkyDeck.cpp
@@ -32,7 +32,7 @@ static void __cdecl SkyDeck_SimulateAltitude_r(Uint16 act)
 
 static void __cdecl SkyBox_SkyDeck_Delete(ObjectMaster*)
 {
-	LanternInstance::SetBlendFactor(0.0f);
+	SetShaderOptions(d3d::ShaderOptions::UseBlending, false);
 }
 static void __cdecl SkyBox_SkyDeck_r(ObjectMaster* _this)
 {
@@ -47,7 +47,7 @@ static void __cdecl SkyBox_SkyDeck_r(ObjectMaster* _this)
 static void __cdecl Obj_SkyDeck_Delete(ObjectMaster* _this)
 {
 	globals::palettes.Remove(handle);
-	LanternInstance::SetBlendFactor(0.0f);
+	SetShaderOptions(d3d::ShaderOptions::UseBlending, false);
 	handle = 0;
 }
 static void __cdecl Obj_SkyDeck_r(ObjectMaster* _this)
@@ -68,6 +68,7 @@ static void __cdecl Obj_SkyDeck_r(ObjectMaster* _this)
 	lantern.LoadPalette(LevelIDs_SkyDeck, 1);
 	handle = globals::palettes.Add(lantern);
 	globals::palettes.SetLastLevel(-1, -1);
+	SetShaderOptions(d3d::ShaderOptions::UseBlending, true);
 }
 
 void SkyDeck_Init()

--- a/sadx-dc-lighting/d3d.cpp
+++ b/sadx-dc-lighting/d3d.cpp
@@ -38,8 +38,6 @@ struct PolyBuff
 };
 #pragma pack(pop)
 
-constexpr auto VERTEX_SHADER_BITS = 0xFF << 16;
-constexpr auto PIXEL_SHADER_BITS = 0xFF << 24;
 constexpr auto DEFAULT_OPTIONS = d3d::UseAlpha | d3d::UseFog | d3d::UseLight | d3d::UseTexture;
 
 static Uint32 shader_options = DEFAULT_OPTIONS;

--- a/sadx-dc-lighting/d3d.cpp
+++ b/sadx-dc-lighting/d3d.cpp
@@ -558,6 +558,11 @@ static auto __stdcall SetTransformHijack(Direct3DDevice8* _device, D3DTRANSFORMS
 
 void releaseShaders()
 {
+	for (auto& i : param::parameters)
+	{
+		i->Release();
+	}
+
 	effect = nullptr;
 
 	for (auto& e : shaders)

--- a/sadx-dc-lighting/d3d.h
+++ b/sadx-dc-lighting/d3d.h
@@ -14,7 +14,7 @@ namespace d3d
 	{
 		None,
 		UseTexture  = 1 << 0,
-		UseEnv      = 1 << 1,
+		UseEnvMap   = 1 << 1,
 		UseAlpha    = 1 << 2,
 		UseLight    = 1 << 3,
 		UseBlending = 1 << 4,
@@ -48,9 +48,6 @@ namespace param
 	extern EffectParameter<D3DXMATRIX> ProjectionMatrix;
 	extern EffectParameter<D3DXMATRIX> wvMatrixInvT;
 	extern EffectParameter<D3DXMATRIX> TextureTransform;
-	extern EffectParameter<bool> TextureEnabled;
-	extern EffectParameter<bool> EnvironmentMapped;
-	extern EffectParameter<bool> AlphaEnabled;
 	extern EffectParameter<int> FogMode;
 	extern EffectParameter<float> FogStart;
 	extern EffectParameter<float> FogEnd;
@@ -67,7 +64,6 @@ namespace param
 #ifdef USE_SL
 	extern EffectParameter<D3DXCOLOR> MaterialSpecular;
 	extern EffectParameter<float> MaterialPower;
-	extern EffectParameter<bool> UseSourceLight;
 	extern EffectParameter<SourceLight_t> SourceLight;
 #endif
 }

--- a/sadx-dc-lighting/d3d.h
+++ b/sadx-dc-lighting/d3d.h
@@ -19,6 +19,9 @@ namespace d3d
 		UseLight    = 1 << 3,
 		UseBlending = 1 << 4,
 		UseFog      = 1 << 5,
+
+		Mask = 0x3F,
+		Count = 64
 	};
 
 	extern IDirect3DDevice9* device;

--- a/sadx-dc-lighting/d3d.h
+++ b/sadx-dc-lighting/d3d.h
@@ -10,10 +10,22 @@
 
 namespace d3d
 {
+	enum ShaderOptions : Uint32
+	{
+		None,
+		UseTexture  = 1 << 0,
+		UseEnv      = 1 << 1,
+		UseAlpha    = 1 << 2,
+		UseLight    = 1 << 3,
+		UseBlending = 1 << 4,
+		UseFog      = 1 << 5,
+	};
+
 	extern IDirect3DDevice9* device;
-	extern ID3DXEffect* effect;
+	extern Effect effect;
 	extern bool do_effect;
 	void LoadShader();
+	void SetShaderOptions(Uint32 options, bool add = true);
 	void InitTrampolines();
 }
 

--- a/sadx-dc-lighting/fog.cpp
+++ b/sadx-dc-lighting/fog.cpp
@@ -30,7 +30,7 @@ static void __cdecl njDisableFog_r()
 
 	if (effect != nullptr)
 	{
-		globals::fog = false;
+		SetShaderOptions(ShaderOptions::UseFog, false);
 	}
 }
 
@@ -41,7 +41,7 @@ static void __cdecl njEnableFog_r()
 	if (effect != nullptr)
 	{
 		param::FogMode = fog_mode;
-		globals::fog = true;
+		SetShaderOptions(ShaderOptions::UseFog, true);
 	}
 }
 
@@ -66,7 +66,7 @@ static void __cdecl njSetFogTable_r(NJS_FOG_TABLE fogtable)
 
 	device->GetRenderState(D3DRS_FOGTABLEMODE, (DWORD*)&fog_mode);
 	param::FogMode = fog_mode;
-	globals::fog = true;
+	SetShaderOptions(ShaderOptions::UseFog, true);
 
 	float start, end, density;
 	device->GetRenderState(D3DRS_FOGSTART, (DWORD*)&start);

--- a/sadx-dc-lighting/globals.cpp
+++ b/sadx-dc-lighting/globals.cpp
@@ -8,8 +8,6 @@
 namespace globals
 {
 	Sint32 light_type = 0;
-	bool fog          = true;
-	bool light        = true;
 	bool no_specular  = false;
 
 #ifdef _DEBUG

--- a/sadx-dc-lighting/globals.h
+++ b/sadx-dc-lighting/globals.h
@@ -10,8 +10,6 @@ namespace globals
 	extern NJS_VECTOR light_dir;
 #endif
 	extern Sint32 light_type;
-	extern bool fog;
-	extern bool light;
 	extern bool no_specular;
 	extern std::string system;
 	extern LanternCollection palettes;

--- a/sadx-dc-lighting/lantern.cpp
+++ b/sadx-dc-lighting/lantern.cpp
@@ -36,11 +36,11 @@ bool SourceLight_t::operator!=(const SourceLight_t& rhs) const
 }
 
 template<>
-void EffectParameter<SourceLight_t>::Commit()
+void EffectParameter<SourceLight_t>::Commit(Effect effect)
 {
 	if (Modified())
 	{
-		(*effect)->SetValue(handle, &current, sizeof(SourceLight_t));
+		effect->SetValue(handle, &current, sizeof(SourceLight_t));
 		Clear();
 	}
 }

--- a/sadx-dc-lighting/lantern.fx
+++ b/sadx-dc-lighting/lantern.fx
@@ -29,35 +29,22 @@ struct PS_IN
 	float  fogDist : FOG;
 };
 
+// This never changes
+static float AlphaRef = 16.0f / 255.0f;
+
+shared float4x4 WorldMatrix;
+shared float4x4 wvMatrix;
+shared float4x4 ProjectionMatrix;
+
+shared float4 MaterialDiffuse = float4(1.0f, 1.0f, 1.0f, 1.0f);
+shared uint   DiffuseSource = (uint)D3DMCS_COLOR1;
+
 shared Texture2D BaseTexture;
 sampler2D baseSampler = sampler_state
 {
 	Texture = <BaseTexture>;
 };
 
-shared Texture2D PaletteA;
-sampler2D atlasSamplerA = sampler_state
-{
-	Texture = <PaletteA>;
-	MinFilter = Point;
-	MagFilter = Point;
-	AddressU = Clamp;
-	AddressV = Clamp;
-};
-
-shared Texture2D PaletteB;
-sampler2D atlasSamplerB = sampler_state
-{
-	Texture = <PaletteB>;
-	MinFilter = Point;
-	MagFilter = Point;
-	AddressU = Clamp;
-	AddressV = Clamp;
-};
-
-shared float4x4 WorldMatrix;
-shared float4x4 wvMatrix;
-shared float4x4 ProjectionMatrix;
 // The inverse transpose of the world view matrix - used for environment mapping.
 shared float4x4 wvMatrixInvT;
 // Used primarily for environment mapping.
@@ -68,8 +55,25 @@ shared float4x4 TextureTransform = {
 	 0.5, 0.5, 0.0, 1.0
 };
 
-// This never changes
-static float AlphaRef = 16.0f / 255.0f;
+shared Texture2D PaletteA;
+sampler2D atlasSamplerA = sampler_state
+{
+	Texture   = <PaletteA>;
+	MinFilter = Point;
+	MagFilter = Point;
+	AddressU  = Clamp;
+	AddressV  = Clamp;
+};
+
+shared Texture2D PaletteB;
+sampler2D atlasSamplerB = sampler_state
+{
+	Texture   = <PaletteB>;
+	MinFilter = Point;
+	MagFilter = Point;
+	AddressU  = Clamp;
+	AddressV  = Clamp;
+};
 
 // Pre-adjusted on the CPU before being sent to the shader.
 shared float DiffuseIndexA  = 0;
@@ -77,17 +81,14 @@ shared float DiffuseIndexB  = 0;
 shared float SpecularIndexA = 0;
 shared float SpecularIndexB = 0;
 
+shared float3 LightDirection = float3(0.0f, -1.0f, 0.0f);
+shared float3 NormalScale = float3(1, 1, 1);
+
 shared uint   FogMode = (uint)FOGMODE_NONE;
 shared float  FogStart;
 shared float  FogEnd;
 shared float  FogDensity;
 shared float4 FogColor;
-
-shared float3 LightDirection  = float3(0.0f, -1.0f, 0.0f);
-shared float4 MaterialDiffuse = float4(1.0f, 1.0f, 1.0f, 1.0f);
-shared uint   DiffuseSource   = (uint)D3DMCS_COLOR1;
-
-shared float3 NormalScale = float3(1, 1, 1);
 
 shared float BlendFactor = 0.0f;
 
@@ -126,6 +127,7 @@ float4 GetDiffuse(in float4 vcolor)
 }
 
 #ifdef USE_FOG
+
 float CalcFogFactor(float d)
 {
 	float fogCoeff;

--- a/sadx-dc-lighting/lantern.fx
+++ b/sadx-dc-lighting/lantern.fx
@@ -29,13 +29,13 @@ struct PS_IN
 	float  fogDist : FOG;
 };
 
-Texture2D BaseTexture;
+shared Texture2D BaseTexture;
 sampler2D baseSampler = sampler_state
 {
 	Texture = <BaseTexture>;
 };
 
-Texture2D PaletteA;
+shared Texture2D PaletteA;
 sampler2D atlasSamplerA = sampler_state
 {
 	Texture = <PaletteA>;
@@ -45,7 +45,7 @@ sampler2D atlasSamplerA = sampler_state
 	AddressV = Clamp;
 };
 
-Texture2D PaletteB;
+shared Texture2D PaletteB;
 sampler2D atlasSamplerB = sampler_state
 {
 	Texture = <PaletteB>;
@@ -55,13 +55,13 @@ sampler2D atlasSamplerB = sampler_state
 	AddressV = Clamp;
 };
 
-float4x4 WorldMatrix;
-float4x4 wvMatrix;
-float4x4 ProjectionMatrix;
+shared float4x4 WorldMatrix;
+shared float4x4 wvMatrix;
+shared float4x4 ProjectionMatrix;
 // The inverse transpose of the world view matrix - used for environment mapping.
-float4x4 wvMatrixInvT;
+shared float4x4 wvMatrixInvT;
 // Used primarily for environment mapping.
-float4x4 TextureTransform = {
+shared float4x4 TextureTransform = {
 	-0.5, 0.0, 0.0, 0.0,
 	 0.0, 0.5, 0.0, 0.0,
 	 0.0, 0.0, 1.0, 0.0,
@@ -72,24 +72,24 @@ float4x4 TextureTransform = {
 static float AlphaRef = 16.0f / 255.0f;
 
 // Pre-adjusted on the CPU before being sent to the shader.
-float DiffuseIndexA = 0;
-float DiffuseIndexB = 0;
-float SpecularIndexA = 0;
-float SpecularIndexB = 0;
+shared float DiffuseIndexA  = 0;
+shared float DiffuseIndexB  = 0;
+shared float SpecularIndexA = 0;
+shared float SpecularIndexB = 0;
 
-uint   FogMode = (uint)FOGMODE_NONE;
-float  FogStart;
-float  FogEnd;
-float  FogDensity;
-float4 FogColor;
+shared uint   FogMode = (uint)FOGMODE_NONE;
+shared float  FogStart;
+shared float  FogEnd;
+shared float  FogDensity;
+shared float4 FogColor;
 
-float3 LightDirection = float3(0.0f, -1.0f, 0.0f);
-float4 MaterialDiffuse = float4(1.0f, 1.0f, 1.0f, 1.0f);
-uint   DiffuseSource = (uint)D3DMCS_COLOR1;
+shared float3 LightDirection  = float3(0.0f, -1.0f, 0.0f);
+shared float4 MaterialDiffuse = float4(1.0f, 1.0f, 1.0f, 1.0f);
+shared uint   DiffuseSource   = (uint)D3DMCS_COLOR1;
 
-float3 NormalScale = float3(1, 1, 1);
+shared float3 NormalScale = float3(1, 1, 1);
 
-float BlendFactor = 0.0f;
+shared float BlendFactor = 0.0f;
 
 #ifdef USE_SL
 
@@ -101,10 +101,11 @@ struct SourceLight_t
 	float power;
 };
 
-bool          UseSourceLight   = false;
-float4        MaterialSpecular = float4(0.0f, 0.0f, 0.0f, 0.0f);
-float         MaterialPower    = 1.0f;
-SourceLight_t SourceLight;
+shared bool   UseSourceLight   = false;
+shared float4 MaterialSpecular = float4(0.0f, 0.0f, 0.0f, 0.0f);
+shared float  MaterialPower    = 1.0f;
+
+shared SourceLight_t SourceLight;
 
 #endif
 

--- a/sadx-dc-lighting/lantern.h
+++ b/sadx-dc-lighting/lantern.h
@@ -29,7 +29,7 @@ union SourceLight
 #pragma pack(pop)
 
 static_assert(sizeof(SourceLight) == 0x60, "SourceLight size mismatch");
-template<> void EffectParameter<SourceLight_t>::Commit();
+template<> void EffectParameter<SourceLight_t>::Commit(Effect effect);
 
 class LanternInstance;
 

--- a/sadx-dc-lighting/mod.cpp
+++ b/sadx-dc-lighting/mod.cpp
@@ -159,20 +159,19 @@ static void __fastcall Direct3D_ParseMaterial_r(NJS_MATERIAL* material)
 
 	Uint32 flags = material->attrflags;
 	Uint32 texid = material->attr_texId & 0xFFFF;
-	bool use_texture = (flags & NJD_FLAG_USE_TEXTURE) != 0;
 
 	if (_nj_control_3d_flag_ & NJD_CONTROL_3D_CONSTANT_ATTR)
 	{
 		flags = _nj_constant_attr_or_ | _nj_constant_attr_and_ & flags;
 	}
 
-	globals::light = (flags & NJD_FLAG_IGNORE_LIGHT) == 0;
-
 	globals::palettes.SetPalettes(globals::light_type, globals::no_specular ? flags | NJD_FLAG_IGNORE_SPECULAR : flags);
 
+	bool use_texture = (flags & NJD_FLAG_USE_TEXTURE) != 0;
 	SetShaderOptions(ShaderOptions::UseTexture, use_texture);
 	SetShaderOptions(ShaderOptions::UseAlpha, (flags & NJD_FLAG_USE_ALPHA) != 0);
 	SetShaderOptions(ShaderOptions::UseEnvMap, (flags & NJD_FLAG_USE_ENV) != 0);
+	SetShaderOptions(ShaderOptions::UseLight, (flags & NJD_FLAG_IGNORE_LIGHT) == 0);
 
 	// Environment map matrix
 	param::TextureTransform = *(D3DXMATRIX*)0x038A5DD0;

--- a/sadx-dc-lighting/mod.cpp
+++ b/sadx-dc-lighting/mod.cpp
@@ -169,9 +169,10 @@ static void __fastcall Direct3D_ParseMaterial_r(NJS_MATERIAL* material)
 	globals::light = (flags & NJD_FLAG_IGNORE_LIGHT) == 0;
 
 	globals::palettes.SetPalettes(globals::light_type, globals::no_specular ? flags | NJD_FLAG_IGNORE_SPECULAR : flags);
-	param::EnvironmentMapped = (flags & NJD_FLAG_USE_ENV) != 0;
-	param::AlphaEnabled = (flags & NJD_FLAG_USE_ALPHA) != 0;
-	param::TextureEnabled = use_texture;
+
+	SetShaderOptions(ShaderOptions::UseTexture, use_texture);
+	SetShaderOptions(ShaderOptions::UseAlpha, (flags & NJD_FLAG_USE_ALPHA) != 0);
+	SetShaderOptions(ShaderOptions::UseEnvMap, (flags & NJD_FLAG_USE_ENV) != 0);
 
 	// Environment map matrix
 	param::TextureTransform = *(D3DXMATRIX*)0x038A5DD0;


### PR DESCRIPTION
This (ab)uses the HLSL preprocessor to compile shaders for specific use cases. This significantly improves performance without having to reduce the number of shader switches.

It could be improved further to separate addressing of vertex and pixel shaders to reduce code redundancy. The only issue there is that it would require basically re-inventing the wheel by implementing would effectively be a custom `ID3DXEffect`, so whether or not it's worth the time is still unknown.